### PR TITLE
Fix test spark jar

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -10,6 +10,8 @@ set :spark_jar_path, "hdfs://hadoop-production/user/sparkles"
 set :gateway, nil
 set :keep_releases, 5
 set :branch, fetch(:branch, `git symbolic-ref --short HEAD`.gsub("\s",""))
+# turns out that fetch(:sha), when combined with packserv, will show only the latest sha on packserv
+set :local_sha, `git rev-parse HEAD`.rstrip
 
 DATANODES = (2..47).map {|i| "dn%02d.chi.shopify.com" % i }
 OTHERNODES = ["hadoop-etl1.chi.shopify.com", "spark-etl1.chi.shopify.com", "reports-reportify-etl3.chi.shopify.com", "reports-reportify-skydb4.chi.shopify.com", "platfora2.chi.shopify.com"]
@@ -42,15 +44,13 @@ namespace :deploy do
   end
 
   task :upload_to_hdfs, :roles => :uploader, :on_no_matching_servers => :continue do
-    # turns out that fetch(:sha), when combined with packserv, will show only the latest sha on packserv
-    local_sha = `git rev-parse HEAD`.rstrip
-    raw_binary_path = "./lib/spark-assembly-1.3.0-SNAPSHOT-hadoop2.0.0-cdh4.7.0.jar"
-    modified_binary_path = "./lib/spark-assembly-#{local_sha}.jar"
+    raw_binary_path = "./assembly/target/scala-2.10/spark-assembly-1.3.0-SNAPSHOT-hadoop2.5.0.jar"
+    modified_binary_path = "./lib/spark-assembly-#{fetch(:local_sha)}.jar"
     if fetch(:branch) == "master"
       run "hdfs dfs -copyFromLocal -f #{release_path}/lib/spark-assembly-*.jar hdfs://hadoop-production/user/sparkles/spark-assembly-#{fetch(:sha)}.jar"
     else
       unless File.exist?(modified_binary_path)
-        system("./make-distribution.sh --skip-java-test $(cat SHOPIFY_HADOOP_OPTIONS)")
+        system("mvn package -DskipTests -Phadoop-2.4 -Dhadoop.version=2.5.0 -Pyarn -Phive")
         system("mv #{raw_binary_path} #{modified_binary_path}")
       end
       system("hdfs dfs -copyFromLocal #{modified_binary_path} hdfs://nn01.chi.shopify.com/user/sparkles")
@@ -58,7 +58,8 @@ namespace :deploy do
   end
 
   task :test_spark_jar, :roles => :uploader, :on_no_master_servers => :continue do
-    run "sudo -u azkaban sh -c '. /u/virtualenvs/starscream/bin/activate && cd /u/apps/starscream/current && PYTHON_ENV=production SPARK_OPTS=\"spark.yarn.jar=hdfs://hadoop-production/user/sparkles/spark-assembly-#{fetch(:sha)}.jar\" exec python shopify/tools/canary.py'"
+    spark_yarn_jar_sha = fetch(:branch) == "master" ? fetch(:sha) : fetch(:local_sha)
+    run "sudo -u azkaban sh -c '. /u/virtualenvs/starscream/bin/activate && cd /u/apps/starscream/current && PYTHON_ENV=production SPARK_OPTS=\"spark.yarn.jar=hdfs://hadoop-production/user/sparkles/spark-assembly-#{spark_yarn_jar_sha}.jar\" exec python shopify/tools/canary.py'"
   end
 
   task :prevent_gateway do


### PR DESCRIPTION
Yesterday I attempted to ship an upstream merge to spark. This merge failed and revealed a primary flaw in our testing, which also revealed a flaw in how we can test.

The problem:

originally deploy:upload_to_hdfs was uploading the spark jar from /u/apps/spark/current *before* the symlink was updated, which means we were always running deploy:test_spark_jar from an incorrect spark jar (and also running spark from the wrong revision *facepalm*

The fix:

This went out already and is on master, but the fix is to make sure that when we do an actual deploy, we upload the spark jar from the releases_path, not current_path.

------

that was context. this PR fixes issues involving our ability to actually upload and test arbitrary spark jars from hdfs. 

```deploy:upload_spark_jar``` - updated to detect whether we have a spark assembly that matches the current local sha (not packserv sha). if it is not present, we need to build it.

```deploy:test_spark_jar``` - test spark jar with the local_sha, not packserv sha.

detailed comments inline.