### PR TITLE
Do not shrink shuffle batch size

### DIFF
--- a/python/pyspark/shuffle.py
+++ b/python/pyspark/shuffle.py
@@ -513,7 +513,6 @@ class ExternalSorter(object):
                 chunks.append(load(open(path, 'rb')))
                 current_chunk = []
                 gc.collect()
-                batch //= 2
                 limit = self._next_limit()
                 MemoryBytesSpilled += max(used_memory - get_used_memory(), 0) << 20
                 DiskBytesSpilled += os.path.getsize(path)


### PR DESCRIPTION
Thanks to @kmtaylor-github's serious gdb digging, we found an infinite loop in Spark's sorting code.

Here's the stack frame that gave it away:

```
0x59b5a60: sorted (/workspace/yarn/nm/filecache/196/spark-assembly-8c9f124c82a9630116a2ac83e0687153582beb5b.jar/pyspark/shuffle.py:483)
                    self: ExternalSorter @ 0x59894d0
                iterator: itertools.chain @ 0x5989490
                     key: function @ 0x597a9b0
                 reverse: False
                   batch: 0
                   limit: 2138.850000
                  chunks: list[14] @ 0x528e518
           current_chunk: list[0] @ 0x7b5b7200
                   chunk: list[0] @ 0x8745248
             used_memory: 2038
                    path: '/workspace/yarn/nm/usercache/azkaban/appcache/application_1431642410289_92698/blockmgr-7b9bf5fb-2ec7-4460-bcf8-1f7f800a452b/python/14944/sort/13'
                       f: file @ 0x30d98810
                    load: function @ 0x7a8f8410
```

The method in question can be found here: https://github.com/Shopify/spark/blob/master/python/pyspark/shuffle.py#L483-L532

And the bug was that `batch` had reached 0.

On every iteration, if the python proc has used too much memory, it spills to disk and stores that file in `chunks`.

When spilling we divide our batch size by 2. This change came from a seemingly unrelated PR about speeding up tests https://github.com/apache/spark/commit/3134c3fe495862b7687b5aa00d3344d09cd5e08e

Once `batch` reaches 0, we infinite loop constantly checking how much memory the process is using. This lines up with @kevincox's `strace` results.

In our case, we spilled 13 times, enough to reach 0.

Let's try removing that division and see how it runs. This should fix the stalled tasks in Storefront Session Facts Resolver, Reportify Pageviews View, API Usage Facts

A big thanks to everyone who helped track down this bug! @kmtaylor-github @jamesemoody @kevincox @airhorns 

@Shopify/data-engineers @snormore @CamDavidsonPilon 