### PR TITLE
Use multiple processes while building.

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -10,4 +10,4 @@ fi
 FWDIR="$(cd `dirname $0`/..; pwd)"
 export HADOOP_OPTIONS="$(cat $FWDIR/SHOPIFY_HADOOP_OPTIONS)"
 export JAVA_HOME=$(/usr/libexec/java_home -v 1.8)
-build/mvn $HADOOP_OPTIONS -DskipTests clean package
+build/mvn $HADOOP_OPTIONS -DskipTests -T1C clean package

--- a/script/watch
+++ b/script/watch
@@ -6,4 +6,4 @@ set -e
 FWDIR="$(cd `dirname $0`/..; pwd)"
 export HADOOP_OPTIONS="$(cat $FWDIR/SHOPIFY_HADOOP_OPTIONS)"
 export MAVEN_OPTS="-Xmx2g -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=512m"
-mvn $HADOOP_OPTIONS scala:cc
+build/mvn $HADOOP_OPTIONS -T1C scala:cc


### PR DESCRIPTION
This uses a number of jobs equal to the number of builders.

@angelini @solackerman @kmtaylor-github 