### PR TITLE
reduce ivy verboseness

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -960,11 +960,6 @@ private[spark] object SparkSubmitUtils {
             ivySettings.setDefaultCache(new File(alternateIvyCache, "cache"))
             new File(alternateIvyCache, "jars")
           }
-        // scalastyle:off println
-        printStream.println(
-          s"Ivy Default Cache set to: ${ivySettings.getDefaultCache.getAbsolutePath}")
-        printStream.println(s"The jars for the packages stored in: $packagesDirectory")
-        // scalastyle:on println
         // create a pattern matcher
         ivySettings.addMatcher(new GlobPatternMatcher)
         // create the dependency resolvers
@@ -980,11 +975,12 @@ private[spark] object SparkSubmitUtils {
         // Turn downloading and logging off for testing
         if (isTest) {
           resolveOptions.setDownload(false)
-          resolveOptions.setLog(LogOptions.LOG_QUIET)
-          retrieveOptions.setLog(LogOptions.LOG_QUIET)
         } else {
           resolveOptions.setDownload(true)
         }
+
+        resolveOptions.setLog(LogOptions.LOG_QUIET)
+        retrieveOptions.setLog(LogOptions.LOG_QUIET)
 
         // A Module descriptor must be specified. Entries are dummy strings
         val md = getModuleDescriptor


### PR DESCRIPTION
For review @angelini  @JasonMWhite 

This reduces the verboseness of Ivy logging. Since `SparkSubmit` jacks stdout and redirects it to stderr, using Log4j doesn't seem to work. If I were to use Log4j, it seems I'd need to set the log level limit to `FATAL`, which seems a little scary, as it might silence real errors when resolving Maven dependencies. 

The alternative was to remove the log information about where the cache / jars are stored, and to set the resovle and retrieve steps to use `LogOptions.LOG_QUIET`. This log option will silence any run-of-the-mill info / debug messages.