### PR TITLE
Compile all starscream dependecies into a single jar.

### DIFF
--- a/SHOPIFY_HADOOP_OPTIONS
+++ b/SHOPIFY_HADOOP_OPTIONS
@@ -1,1 +1,1 @@
--Phadoop-2.4 -Dhadoop.version=2.6.0 -Pyarn -Phive
+-Phadoop-2.4 -Dhadoop.version=2.6.0 -Pyarn -Phive -Pstarscream-assembly

--- a/bin/spark-submit
+++ b/bin/spark-submit
@@ -22,4 +22,12 @@ SPARK_HOME="$(cd "`dirname "$0"`"/..; pwd)"
 # disable randomized hash for string in Python 3.3+
 export PYTHONHASHSEED=0
 
-exec "$SPARK_HOME"/bin/spark-class org.apache.spark.deploy.SparkSubmit "$@"
+if [ -f "$SPARK_HOME/RELEASE" ]; then
+  STARSCREAM_ASSEMBLY_DIR="$SPARK_HOME/lib"
+else
+  STARSCREAM_ASSEMBLY_DIR="$SPARK_HOME/external/starscream-assembly/target"
+fi
+
+ASSEMBLY_JAR="$(ls -1 "$STARSCREAM_ASSEMBLY_DIR" | grep "^starscream-assembly.*\.jar$" || true)"
+
+exec "$SPARK_HOME"/bin/spark-class org.apache.spark.deploy.SparkSubmit --jars "${STARSCREAM_ASSEMBLY_DIR}/${ASSEMBLY_JAR}" "$@"

--- a/external/starscream-assembly/pom.xml
+++ b/external/starscream-assembly/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.spark</groupId>
+    <artifactId>spark-parent_2.10</artifactId>
+    <version>1.5.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <repositories>
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+    </repository>
+  </repositories>
+
+  <groupId>com.shopify</groupId>
+  <artifactId>starscream-assembly</artifactId>
+  <packaging>pom</packaging>
+  <version>0.1</version>
+  <name>Starscream dependencies</name>
+
+  <properties>
+    <java.version>1.7</java.version>
+    <scala.version>2.10.4</scala.version>
+    <scala.version.prefix>2.10</scala.version.prefix>
+    <spark.version>1.5.0</spark.version>
+    <maven.release.plugin.version>2.4.1</maven.release.plugin.version>
+    <maven.test.skip>true</maven.test.skip>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-streaming_2.10</artifactId>
+      <version>1.5.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scala.version.prefix}</artifactId>
+      <version>${spark.version}</version>
+      <scope>provided</scope>
+    </dependency>    
+    <dependency>
+      <groupId>com.github.damnMeddlingKid</groupId>
+      <artifactId>spark-named-inputformat</artifactId>
+      <version>1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.JasonMWhite</groupId>
+      <artifactId>spark-datadog-relay</artifactId>
+      <version>v0.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-streaming-kafka_2.10</artifactId>
+      <version>${spark.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <skipTests>true</skipTests>
+          <shadedArtifactAttached>false</shadedArtifactAttached>
+          <outputFile>target/starscream-assembly-${spark.version}.jar</outputFile>
+          <artifactSet>
+            <includes>
+              <include>*:*</include>
+            </includes>
+          </artifactSet>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/*.SF</exclude>
+                <exclude>META-INF/*.DSA</exclude>
+                <exclude>META-INF/*.RSA</exclude>
+              </excludes>
+            </filter>
+          </filters>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/make-distribution.sh
+++ b/make-distribution.sh
@@ -183,6 +183,7 @@ echo "Build flags: $@" >> "$DISTDIR/RELEASE"
 
 # Copy jars
 cp "$SPARK_HOME"/assembly/target/scala*/*assembly*hadoop*.jar "$DISTDIR/lib/"
+cp "$SPARK_HOME"/external/starscream-assembly/target/starscream-assembly-*.jar "$DISTDIR/lib/"
 cp "$SPARK_HOME"/examples/target/scala*/spark-examples*.jar "$DISTDIR/lib/"
 # This will fail if the -Pyarn profile is not provided
 # In this case, silence the error and ignore the return code of this command

--- a/pom.xml
+++ b/pom.xml
@@ -2454,6 +2454,13 @@
       </properties>
     </profile>
 
+    <profile>
+      <id>starscream-assembly</id>
+      <modules>
+        <module>external/starscream-assembly</module>
+      </modules>
+    </profile>
+
     <!--
       These empty profiles are available in some sub-modules. Declare them here so that
       maven does not complain when they're provided on the command line for a sub-module


### PR DESCRIPTION
Fix for Shopify/starscream#7282, Packaging the dependencies along with spark at spark build time.

Added a pom file to build a fat jar out of all our custom java stuff, this jar is built along with spark and inserted in the spark/lib folder.

i've tested it locally but im still in the process of testing on remote, would love to get opinions on the maven and modifying spark-submit to inject the jar.