### PR TITLE
Loading all the plugins when creating the UI

### DIFF
--- a/history/src/main/scala/org/apache/spark/deploy/history/SimpleFsHistoryProvider.scala
+++ b/history/src/main/scala/org/apache/spark/deploy/history/SimpleFsHistoryProvider.scala
@@ -116,7 +116,8 @@ private[history] class SimpleFsHistoryProvider(conf: SparkConf, clock: Clock)
           attemptInfo.info.startTime.getTime(),
           attemptInfo.info.appSparkVersion
         )
-
+        loadPlugins().foreach(_.setupUI(ui))
+        
         LoadedAppUI(ui)
       })
     })
@@ -141,7 +142,6 @@ private[history] class SimpleFsHistoryProvider(conf: SparkConf, clock: Clock)
     // actually read, we may never refresh the app.  FileStatus is guaranteed to be static
     // after it's created, so we get a file size that is no bigger than what is actually read.
     Utils.tryWithResource(EventLoggingListener.openEventLog(logPath, fs)) { in =>
-      logInfo("Trying to replay bus: $isCompleted, $eventsFilter")
       bus.replay(in, logPath.toString, !isCompleted, eventsFilter)
       logInfo(s"Finished parsing $logPath")
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The SQL tab was not appearing for any job, including Spark SQL based jobs.

## How was this patch tested?

Loading all plugins in the UI for every job, not just some of them.

Please review http://spark.apache.org/contributing.html before opening a pull request.
